### PR TITLE
[4.0] [a11y] atum Underlined links

### DIFF
--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -53,7 +53,7 @@ use Joomla\CMS\Router\Route;
 							<li class="list-group-item d-flex align-items-center">
 								<a class="flex-grow-1" href="<?php echo $item->link; ?>"
 									<?php echo $item->target === '_blank' ? ' title="' . Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_($item->title)) . '"' : ''; ?>
-									<?php echo $item->target ? ' target="' . $item->target . '"' : ''; ?>>
+									<?php echo $item->target ? ' target="' . $item->target . '"' : ''; ?>><u>
 									<?php if (!empty($params->get('menu_image'))) : ?>
 										<?php
 										$image = htmlspecialchars($params->get('menu_image'), ENT_QUOTES, 'UTF-8');
@@ -67,7 +67,7 @@ use Joomla\CMS\Router\Route;
 										<span class="menu-badge">
 											<span class="icon-spin icon-spinner mt-1 system-counter float-end" data-url="<?php echo $item->ajaxbadge; ?>"></span>
 										</span>
-									<?php endif; ?>
+									<?php endif; ?></u>
 								</a>
 								<?php if ($params->get('menu-quicktask')) : ?>
 									<?php $permission = $params->get('menu-quicktask-permission'); ?>


### PR DESCRIPTION
Pull Request for Issue #33629 .

### Summary of Changes
The links in list earlier were not underlined.


### Testing Instructions
Apply this patch, build the CSS , and have a look on links in dashboard 


### Actual result BEFORE applying this Pull Request
Links were not underlined

### Expected result AFTER applying this Pull Request
Links are underlined

![p2](https://user-images.githubusercontent.com/65963997/117706714-43ed7b00-b1eb-11eb-8308-fcdafdc327ff.gif)

### Documentation Changes Required

