### PR TITLE
[4.0] Toolbar items sizing issue

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -48,6 +48,11 @@ body {
       text-decoration: underline !important;
       border: #f00 dotted 1px;
     }
+
+    a.header-item-content {
+      padding:0px !important;
+    }
+
   }
 }
 


### PR DESCRIPTION
Pull Request for Issue #34109 .

### Summary of Changes
On enabling Highlight Links in accessibility, there was mismatch in size of toolbar items because of additional padding.
But keeping accessibility in mind, other things should be left unchanged, therefore just removed the padding.


### Testing Instructions
- apply the patch and rebuild css <code>npm run build:css</code>
- turn highlight links on from accessibility and note, size doesnt change

### Actual result BEFORE applying this Pull Request
<img width="711" alt="old" src="https://user-images.githubusercontent.com/65963997/119274356-19f57900-bc2d-11eb-8a44-dc867eff3443.png">

### Expected result AFTER applying this Pull Request
![ss](https://user-images.githubusercontent.com/65963997/119274360-211c8700-bc2d-11eb-8148-980a07d4a8ea.gif)



### Documentation Changes Required

